### PR TITLE
chore: recommend eslint instead of tslint

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,6 @@
 	// See http://go.microsoft.com/fwlink/?LinkId=827846
 	// for the documentation about the extensions.json format
 	"recommendations": [
-		"eg2.tslint"
+		"dbaeumer.vscode-eslint"
 	]
 }


### PR DESCRIPTION
Just installed the extension for VSC!
I was hoping to make a couple of pull requests, this is the first since it's simplest. ^-^'

The TSLint extension is deprecated, it'd be better to recommend the ESLint extension instead.

eg2.tslint -> ms-vscode.vscode-typescript-tslint-plugin -> dbaeumer.vscode-eslint

> Note: This extension has been deprecated in favor of the vscode-typescript-tslint-plugin. To learn about the differences between vscode-tslint and the new extension please refer to this document.
> \- https://marketplace.visualstudio.com/items?itemName=eg2.tslint

> ❗IMPORTANT: TSLint has been deprecated in favor of ESLint.
> Please look into migrating your projects to ESLint.
> \- https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-tslint-plugin