### PR TITLE
feat: add option to include file url

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@ Start command palette (with <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> or <kb
 
 ```JavaScript
 {
-    // Number of seconds the list of `.gitignore` files retrieved from github will be cached
-    "gitignore.cacheExpirationInterval": 3600
+	// Number of seconds the list of `.gitignore` files retrieved from GitHub will be cached.
+	"gitignore.cacheExpirationInterval": 3600,
+	// Prepend a comment with the URL to the file on GitHub.
+	"gitignore.includeUrl": false
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,12 @@
 				"gitignore.cacheExpirationInterval": {
 					"type": "integer",
 					"default": 3600,
-					"description": "Number of seconds the list of `.gitignore` files retrieved from github will be cached"
+					"description": "Number of seconds the list of `.gitignore` files retrieved from GitHub will be cached."
+				},
+				"gitignore.includeUrl": {
+					"type": "boolean",
+					"default": false,
+					"description": "Prepend a comment with the URL to the file on GitHub."
 				}
 			}
 		},
@@ -76,7 +81,8 @@
 		"watch-tests": "tsc -p . -w --outDir out",
 		"pretest": "npm run compile-tests && npm run compile && npm run lint",
 		"lint": "eslint src --ext ts",
-		"test": "node ./out/test/runTest.js"
+		"test": "node ./out/test/runTest.js",
+		"test:headless": "xvfb-run -a npm run test"
 	},
 	"devDependencies": {
 		"@types/glob": "^7.2.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,6 @@ import { Cache } from './cache';
 import { GitignoreTemplate, GitignoreOperation, GitignoreOperationType, GitignoreProvider } from './interfaces';
 import { GithubGitignoreRepositoryProvider } from './providers/github-gitignore-repository';
 
-
 class CancellationError extends Error {
 
 }
@@ -15,15 +14,13 @@ interface GitignoreQuickPickItem extends vscode.QuickPickItem {
 	template: GitignoreTemplate;
 }
 
-
 // Initialize
 const config = vscode.workspace.getConfiguration('gitignore');
 const cache = new Cache(config.get('cacheExpirationInterval', 3600));
 
 // Create gitignore repository provider
 const gitignoreRepository: GitignoreProvider = new GithubGitignoreRepositoryProvider(cache);
-//const gitignoreRepository : GitignoreProvider = new GithubGitignoreApiProvider(cache);
-
+// const gitignoreRepository: GitignoreProvider = new GithubGitignoreApiProvider(cache);
 
 /**
  * Resolves the workspace folder by

--- a/src/providers/github-gitignore-api.ts
+++ b/src/providers/github-gitignore-api.ts
@@ -1,8 +1,8 @@
+import * as vscode from 'vscode';
 import * as https from 'https';
 import * as fs from 'fs';
 import * as url from 'url';
 import { WriteStream } from 'fs';
-
 
 import { Cache, CacheItem } from '../cache';
 import { GitignoreProvider, GitignoreTemplate, GitignoreOperation, GitignoreOperationType } from '../interfaces';
@@ -84,6 +84,13 @@ export class GithubGitignoreApiProvider implements GitignoreProvider {
 			// If appending to the existing .gitignore file, write a NEWLINE as separator
 			if(flags === 'a') {
 				file.write('\n');
+			}
+
+			const config = vscode.workspace.getConfiguration('gitignore');
+			const includeUrl = config.get('includeUrl', false);
+
+			if (includeUrl) {
+				file.write(`# https://github.com/github/gitignore/blob/main/${operation.template.path}\n`);
 			}
 
 			/*

--- a/src/providers/github-gitignore-repository.ts
+++ b/src/providers/github-gitignore-repository.ts
@@ -1,3 +1,4 @@
+import * as vscode from 'vscode';
 import * as https from 'https';
 import * as fs from 'fs';
 import * as url from 'url';
@@ -118,6 +119,13 @@ export class GithubGitignoreRepositoryProvider implements GitignoreProvider {
 			// If appending to the existing .gitignore file, write a NEWLINE as separator
 			if(flags === 'a') {
 				file.write('\n');
+			}
+
+			const config = vscode.workspace.getConfiguration('gitignore');
+			const includeUrl = config.get('includeUrl', false);
+
+			if (includeUrl) {
+				file.write(`# https://github.com/github/gitignore/blob/main/${operation.template.path}\n`);
 			}
 
 			/*


### PR DESCRIPTION
Adds the option to include a link to the references gitignore file in the README.
I prefer to add a link, so contributors know where it was derived from.

When the setting is enabled, the output looks like the following:
```gitignore
# https://raw.githubusercontent.com/github/gitignore/master/Maven.gitignore
target/
pom.xml.tag
pom.xml.releaseBackup
pom.xml.versionsBackup
pom.xml.next
release.properties
dependency-reduced-pom.xml
buildNumber.properties
.mvn/timing.properties
# https://github.com/takari/maven-wrapper#usage-without-binary-jar
.mvn/wrapper/maven-wrapper.jar
```