### PR TITLE
i18n: pull out strings in package.json

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing
+
+## Prerequisites
+
+* [Git](https://git-scm.com/)
+* [Node.js](https://nodejs.org/)
+
+## Getting Started
+
+Clone the repository and install dependencies:
+
+```sh
+git clone https://github.com/CodeZombieCH/vscode-gitignore.git
+cd vscode-gitignore
+npm i
+```
+
+## Debugging
+
+To debug the extension, run the following command to compile and watch for changes:
+
+```
+npm run watch
+```
+
+You'll find the output from Webpack in the `dist/` directory, these are the sources that's bundled into the extension, so put breakpoints here.
+
+## Testing
+
+Before pushing back any changes or opening a pull request, you should run the tests locally.
+
+```sh
+npm run test
+```
+
+If you're on Linux and have [xvfb](https://www.x.org/releases/X11R7.7/doc/man/man1/Xvfb.1.xhtml) installed, you can run the tests in a headless process:
+
+```sh
+npm run test:headless
+```
+
+Check your distributions package manager for how to install it. On Debian based distributions for example, you can use `apt-file` to search for packages that provide the `xvfb-run` binary.
+
+```sh
+apt-file search xvfb-run
+```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "gitignore",
-	"displayName": "gitignore",
-	"description": "Lets you pull .gitignore templates from the https://github.com/github/gitignore repository. Language support for .gitignore files.",
+	"displayName": "%displayName%",
+	"description": "%description%",
 	"version": "0.9.0",
 	"author": "Marc-André Bühler",
 	"publisher": "codezombiech",
@@ -38,12 +38,12 @@
 		],
 		"configuration": {
 			"type": "object",
-			"title": "gitignore extension configuration",
+			"title": "%config.title%",
 			"properties": {
 				"gitignore.cacheExpirationInterval": {
 					"type": "integer",
 					"default": 3600,
-					"description": "Number of seconds the list of `.gitignore` files retrieved from github will be cached"
+					"description": "%config.cacheExpirationInterval%"
 				}
 			}
 		},

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,0 +1,6 @@
+{
+	"displayName": "gitignore",
+	"description": "Lets you pull .gitignore templates from the https://github.com/github/gitignore repository. Language support for .gitignore files.",
+	"config.title": "gitignore",
+	"config.cacheExpirationInterval": "Number of seconds the list of `.gitignore` files retrieved from github will be cached."
+}


### PR DESCRIPTION
This just pulls out some strings from the `package.json` file.

The name and description of the extension.
The names/descriptions of the configuration values.

This makes it easy to translate them for other users.

> The value for the description property should be added to `package.nls.json` and then referenced in the `package.json` file for localization support.
> \- https://code.visualstudio.com/api/extension-guides/workspace-trust#static-declarations

I have another PR (https://github.com/CodeZombieCH/vscode-gitignore/pull/32) that will add a new setting if merged.
When/if this gets merged, I can change that to use the `package.nls.json` as well.

Translations can be added by creating `package.nls.{lang}.json` files, such as `package.nls.fr.json` for French, the rest is handled by Visual Studio Code automatically.

---

Could I also propose changing `gitignore extension configuration` to either (in order of how much I like them):
* Git Ignore
* Gitignore
* gitignore

The "extension" part is redundant because it's already in the "extension" section.
And the "configuration" part is redundant because we're already in the VS Code settings.

![image](https://user-images.githubusercontent.com/22801583/125258890-101ff600-e2ff-11eb-985a-5ae00dddf36c.png)  
You can see it looks a bit out of place there.