### PR TITLE
fix: dont add new line if empty

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,5 +1,4 @@
-import { WriteStream } from "fs";
-
+import * as fs from 'fs';
 
 export interface GitignoreTemplate {
 	name: string;
@@ -11,7 +10,7 @@ export interface GitignoreTemplate {
 export interface GitignoreProvider {
 	getTemplates(): Promise<GitignoreTemplate[]>;
 	download(operation: GitignoreOperation): Promise<void>;
-	downloadToStream(operation: GitignoreOperation, stream: WriteStream): Promise<void>;
+	downloadToStream(operation: GitignoreOperation, stream: fs.WriteStream): Promise<void>;
 }
 
 export enum GitignoreOperationType {
@@ -29,4 +28,8 @@ export interface GitignoreOperation {
 	 * gitignore template file to use
 	 */
 	template: GitignoreTemplate;
+	/**
+	 * If the file already exists, then the stats of the file.
+	 */
+	stats?: fs.Stats;
 }

--- a/src/providers/github-gitignore-api.ts
+++ b/src/providers/github-gitignore-api.ts
@@ -82,7 +82,7 @@ export class GithubGitignoreApiProvider implements GitignoreProvider {
 			const file = fs.createWriteStream(operation.path, { flags: flags });
 
 			// If appending to the existing .gitignore file, write a NEWLINE as separator
-			if(flags === 'a') {
+			if(flags === 'a' && operation.stats?.size !== 0) {
 				file.write('\n');
 			}
 

--- a/src/providers/github-gitignore-repository.ts
+++ b/src/providers/github-gitignore-repository.ts
@@ -116,7 +116,7 @@ export class GithubGitignoreRepositoryProvider implements GitignoreProvider {
 			const file = fs.createWriteStream(operation.path, { flags: flags });
 
 			// If appending to the existing .gitignore file, write a NEWLINE as separator
-			if(flags === 'a') {
+			if(flags === 'a' && operation.stats?.size !== 0) {
 				file.write('\n');
 			}
 


### PR DESCRIPTION
If a `.gitignore` file does exist, it adds a new line to the file even if the file is empty.

This checks the length of the file first, and will only append the initial new line if there was actually any content in the `.gitignore` file in the first place.

This way, if the extension is used to append content to an empty file, it won't leave a blank line on line 1.