### PR TITLE
feat: simplify Cache file and improve the code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.10.0
+
+- Simplify `Cache` file and improve the code
 
 ## v0.9.0
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "gitignore",
 	"displayName": "gitignore",
 	"description": "Lets you pull .gitignore templates from the https://github.com/github/gitignore repository. Language support for .gitignore files.",
-	"version": "0.9.0",
+	"version": "0.10.0",
 	"author": "Marc-André Bühler",
 	"publisher": "codezombiech",
 	"icon": "icon.png",

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -5,27 +5,12 @@
  * but I had too much fun in implementing it on my own.
  */
 
-export interface CacheItemStore {
-	[key: string]: CacheItem;
-}
+type CacheItemStore = Map<string, CacheItem>;
 
 export class CacheItem {
-	private _key: string;
-	private _value: unknown;
-	private storeDate: Date;
+	private readonly storeDate: Date = new Date();
 
-	get key() {
-		return this._key;
-	}
-
-	get value() {
-		return this._value;
-	}
-
-	constructor(key: string, value: unknown) {
-		this._key = key;
-		this._value = value;
-		this.storeDate = new Date();
+	constructor(readonly key: string, readonly value: unknown) {
 	}
 
 	public isExpired(expirationInterval: number) {
@@ -34,45 +19,21 @@ export class CacheItem {
 }
 
 export class Cache {
-	/**
-	 * The key value store (a simple JavaScript object)
-	 */
-	private _store: CacheItemStore;
-	/**
-	 * Cache expiration intervall in seconds
-	 */
-	private _cacheExpirationInterval: number;
+	private store: CacheItemStore = new Map();
 
-	constructor(cacheExpirationInterval: number) {
-		this._store = {};
-		this._cacheExpirationInterval = cacheExpirationInterval;
+	constructor(readonly cacheExpirationInterval: number) {
 	}
 
-	public add(item: CacheItem) {
-		this._store[item.key] = item;
+	public add(item: CacheItem): void {
+		this.store.set(item.key, item);
 	}
 
-	public get(key: string) {
-		const item = this._store[key];
+	public get(key: string): CacheItem | undefined {
+		const item = this.store.get(key);
 
-		// Check expiration
-		if(typeof item === 'undefined' || item.isExpired(this._cacheExpirationInterval)) {
-			return undefined;
-		}
-		else {
-			return item.value;
-		}
-	}
-
-	public getCacheItem(key: string) {
-		const item = this._store[key];
-
-		// Check expiration
-		if(typeof item === 'undefined' || item.isExpired(this._cacheExpirationInterval)) {
-			return undefined;
-		}
-		else {
-			return item;
-		}
+		return typeof item === "undefined" ||
+			item.isExpired(this.cacheExpirationInterval)
+			? undefined
+			: item;
 	}
 }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -5,8 +5,6 @@
  * but I had too much fun in implementing it on my own.
  */
 
-type CacheItemStore = Map<string, CacheItem>;
-
 export class CacheItem {
 	readonly storeDate: Date = new Date();
 
@@ -19,7 +17,7 @@ export class CacheItem {
 }
 
 export class Cache {
-	private store: CacheItemStore = new Map();
+	private store = new Map<string, CacheItem>();
 
 	constructor(readonly cacheExpirationInterval: number) {
 	}

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -8,12 +8,12 @@
 type CacheItemStore = Map<string, CacheItem>;
 
 export class CacheItem {
-	private readonly storeDate: Date = new Date();
+	readonly storeDate: Date = new Date();
 
 	constructor(readonly key: string, readonly value: unknown) {
 	}
 
-	public isExpired(expirationInterval: number) {
+	isExpired(expirationInterval: number) {
 		return this.storeDate.getTime() + expirationInterval * 1000 < Date.now();
 	}
 }
@@ -24,11 +24,11 @@ export class Cache {
 	constructor(readonly cacheExpirationInterval: number) {
 	}
 
-	public add(item: CacheItem): void {
+	add(item: CacheItem): void {
 		this.store.set(item.key, item);
 	}
 
-	public get(key: string): CacheItem | undefined {
+	get(key: string): CacheItem | undefined {
 		const item = this.store.get(key);
 
 		return typeof item === "undefined" ||

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -6,7 +6,7 @@
  */
 
 export class CacheItem {
-	readonly storeDate: Date = new Date();
+	readonly storeDate = new Date();
 
 	constructor(readonly key: string, readonly value: unknown) {
 	}
@@ -29,9 +29,13 @@ export class Cache {
 	get(key: string): CacheItem | undefined {
 		const item = this.store.get(key);
 
-		return typeof item === "undefined" ||
-			item.isExpired(this.cacheExpirationInterval)
-			? undefined
-			: item;
+		if (
+			typeof item !== "undefined"
+			&& item.isExpired(this.cacheExpirationInterval)
+		) {
+			this.store.delete(key);
+			return undefined;
+		}
+		return item;
 	}
 }

--- a/src/providers/github-gitignore-api.ts
+++ b/src/providers/github-gitignore-api.ts
@@ -22,7 +22,7 @@ export class GithubGitignoreApiProvider implements GitignoreProvider {
 	 */
 	public getTemplates(): Promise<GitignoreTemplate[]> {
 		// If cached, return cached content
-		const item = this.cache.get('gitignore') as GitignoreTemplate[];
+		const item = this.cache.get('gitignore')?.value as GitignoreTemplate[];
 		if(typeof item !== 'undefined') {
 			return Promise.resolve<GitignoreTemplate[]>(item);
 		}

--- a/src/providers/github-gitignore-repository.ts
+++ b/src/providers/github-gitignore-repository.ts
@@ -44,7 +44,7 @@ export class GithubGitignoreRepositoryProvider implements GitignoreProvider {
 	private getFiles(path = ''): Promise<GitignoreTemplate[]> {
 		return new Promise((resolve, reject) => {
 			// If cached, return cached content
-			const item = this.cache.get('gitignore/' + path) as GitignoreTemplate[];
+			const item = this.cache.get('gitignore/' + path)?.value as GitignoreTemplate[];
 			if(typeof item !== 'undefined') {
 				resolve(item);
 				return;


### PR DESCRIPTION
# Changed

- Based on Google's typescript conventions, I deleted underscores used as variables prefix/suffix.
- The `store` type now use a *Map* rather than a simple object as I think it's more powerful for storing *key-value* data.
- Define `CacheItemStore` with the `type` keyword and is based on the `Map<string, CacheItem>` type declaration.
- Deleted **almost** duplicated function is the Cache class (get / getItemCache)
  - now use `get` function to get the cached item and its `readonly` *value* to get its value.
- Deleted `CacheItem` *key* and *value* getters and use `readonly` keyword
- Update version in `package.json` & changelog
- Remove `public` modifier as it may be redundant cause' of TS symbols are public by default.