### PR TITLE
Add multi-select gitignore templates with deduplication

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "gitignore",
-	"version": "0.10.0-alpha.1",
+	"version": "0.10.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "gitignore",
-			"version": "0.10.0-alpha.1",
+			"version": "0.10.0",
 			"license": "MIT",
 			"dependencies": {
 				"https-proxy-agent": "^7.0.6"
@@ -15,7 +15,7 @@
 				"@eslint/js": "^9.21.0",
 				"@types/mocha": "^10.0.10",
 				"@types/node": "^22.13.5",
-				"@types/vscode": ">=1.63.0 <1.64.0",
+				"@types/vscode": ">=1.66.0 <1.67.0",
 				"@typescript-eslint/eslint-plugin": "^8.22.0",
 				"@typescript-eslint/parser": "^8.22.0",
 				"@vscode/test-cli": "^0.0.10",
@@ -28,7 +28,7 @@
 				"typescript-eslint": "^8.25.0"
 			},
 			"engines": {
-				"vscode": "^1.63.0"
+				"vscode": "^1.66.0"
 			}
 		},
 		"node_modules/@azure/abort-controller": {
@@ -1007,9 +1007,9 @@
 			}
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.63.2",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.63.2.tgz",
-			"integrity": "sha512-awvdx4vX7SkMKyvWIlRjycjb4blYRSQI3Bav0YMn+lJLGN6gJgb20urN/dQCv/2ejDu5S6ADEBt6O15DOpIAkg==",
+			"version": "1.66.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.66.0.tgz",
+			"integrity": "sha512-ZfJck4M7nrGasfs4A4YbUoxis3Vu24cETw3DERsNYtDZmYSYtk6ljKexKFKhImO/ZmY6ZMsmegu2FPkXoUFImA==",
 			"dev": true,
 			"license": "MIT"
 		},

--- a/package.json
+++ b/package.json
@@ -44,6 +44,11 @@
 					"type": "integer",
 					"default": 3600,
 					"description": "Number of seconds the list of `.gitignore` files retrieved from github will be cached"
+				},
+				"gitignore.deduplicateLines": {
+					"type": "boolean",
+					"default": true,
+					"description": "Remove duplicate pattern lines when merging multiple .gitignore templates"
 				}
 			}
 		},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import { GitignoreTemplate, GitignoreOperation, GitignoreOperationType, Gitignor
 import { GithubGitignoreRepositoryProvider } from './providers/github-gitignore-repository';
 import { AuthenticationCancellationError, GithubContext, GithubSession } from './github/session';
 import { GithubApiRateLimitReachedError } from './github/client';
-import { mergeTemplates } from './merge';
+import { mergeTemplates, TemplateSection } from './merge';
 
 
 class CancellationError extends Error {
@@ -106,7 +106,7 @@ export async function writeGitignoreFile(gitignoreRepository: GitignoreProvider,
 			operation.templates.map(t => gitignoreRepository.downloadAsString(t.path))
 		);
 
-		const sections = operation.templates.map((t, i) => ({
+		const sections: TemplateSection[] = operation.templates.map((t, i) => ({
 			name: t.name,
 			content: contents[i]
 		}));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import { GitignoreTemplate, GitignoreOperation, GitignoreOperationType, Gitignor
 import { GithubGitignoreRepositoryProvider } from './providers/github-gitignore-repository';
 import { AuthenticationCancellationError, GithubContext, GithubSession } from './github/session';
 import { GithubApiRateLimitReachedError } from './github/client';
+import { mergeTemplates } from './merge';
 
 
 class CancellationError extends Error {
@@ -50,25 +51,20 @@ function createNeverUsedCache() : Cache {
  * - using the single opened workspace
  * - prompting for the workspace to use when multiple workspaces are open
  */
-async function resolveWorkspaceFolder(gitIgnoreTemplate: GitignoreTemplate) {
+async function resolveWorkspaceFolder(gitIgnoreTemplates: GitignoreTemplate[]) {
 	const folders = vscode.workspace.workspaceFolders;
-	// folders being falsy can have two reasons:
-	// 1. no folder (workspace) open
-	//    --> should never be the case as already handled before
-	// 2. the version of vscode does not support the workspaces
-	//    --> should never be the case as we require a vscode with support for it
 	if (!folders) {
 		throw new CancellationError();
 	}
 	else if (folders.length === 1) {
-		return { template: gitIgnoreTemplate, path: folders[0].uri.fsPath };
+		return { templates: gitIgnoreTemplates, path: folders[0].uri.fsPath };
 	}
 	else {
 		const folder = await vscode.window.showWorkspaceFolderPick();
 		if (!folder) {
 			throw new CancellationError();
 		}
-		return { template: gitIgnoreTemplate, path: folder.uri.fsPath };
+		return { templates: gitIgnoreTemplates, path: folder.uri.fsPath };
 	}
 }
 
@@ -84,13 +80,12 @@ function checkIfFileExists(path: string) {
 	});
 }
 
-async function checkExistenceAndPromptForOperation(path: string, template: GitignoreTemplate): Promise<GitignoreOperation> {
+async function checkExistenceAndPromptForOperation(path: string, templates: GitignoreTemplate[]): Promise<GitignoreOperation> {
 	path = joinPath(path, '.gitignore');
 
 	const exists = await checkIfFileExists(path);
 	if (!exists) {
-		// File does not exists -> we are fine to create it
-		return { path, template, type: GitignoreOperationType.Overwrite };
+		return { path, templates, type: GitignoreOperationType.Overwrite };
 	}
 
 	const operation = await promptForOperation();
@@ -100,25 +95,34 @@ async function checkExistenceAndPromptForOperation(path: string, template: Gitig
 	const typedString = <keyof typeof GitignoreOperationType>operation.label;
 	const type = GitignoreOperationType[typedString];
 
-	return { path, template, type };
+	return { path, templates, type };
 }
 
-export async function downloadGitignoreFile(gitignoreRepository: GitignoreProvider, operation: GitignoreOperation) {
+export async function writeGitignoreFile(gitignoreRepository: GitignoreProvider, operation: GitignoreOperation) {
 	const flags = operation.type === GitignoreOperationType.Overwrite ? 'w' : 'a';
-	const fileStream = fs.createWriteStream(operation.path, { flags: flags });
-
-	// If appending to the existing .gitignore file, write a NEWLINE as separator
-	if(flags === 'a') {
-		fileStream.write('\n');
-	}
 
 	try {
-		// Store the file on file system
-		await gitignoreRepository.downloadToStream(operation.template.path, fileStream);
+		const contents = await Promise.all(
+			operation.templates.map(t => gitignoreRepository.downloadAsString(t.path))
+		);
+
+		const sections = operation.templates.map((t, i) => ({
+			name: t.name,
+			content: contents[i]
+		}));
+
+		const config = vscode.workspace.getConfiguration('gitignore');
+		const deduplicate = config.get('deduplicateLines', true);
+		let merged = mergeTemplates(sections, deduplicate);
+
+		if (flags === 'a') {
+			merged = '\n' + merged;
+		}
+
+		fs.writeFileSync(operation.path, merged, { flag: flags });
 	}
 	catch(error) {
-		// Delete the .gitignore file if we created it
-		if(flags === 'w') {
+		if (flags === 'w') {
 			fs.unlink(operation.path, err => {
 				if(err) {
 					console.error(`vscode-gitignore: ${err.message}`);
@@ -143,11 +147,15 @@ function promptForOperation() {
 }
 
 function showSuccessMessage(operation: GitignoreOperation) {
+	const templateDesc = operation.templates.length === 1
+		? operation.templates[0].path
+		: `${operation.templates.length} templates`;
+
 	switch (operation.type) {
 		case GitignoreOperationType.Append:
-			return vscode.window.showInformationMessage(`Appended ${operation.template.path} to the existing .gitignore in the project root`);
+			return vscode.window.showInformationMessage(`Appended ${templateDesc} to the existing .gitignore in the project root`);
 		case GitignoreOperationType.Overwrite:
-			return vscode.window.showInformationMessage(`Created .gitignore file in the project root based on ${operation.template.path}`);
+			return vscode.window.showInformationMessage(`Created .gitignore file in the project root based on ${templateDesc}`);
 		default:
 			throw new Error('Unsupported operation');
 	}
@@ -174,30 +182,29 @@ export function activate(context: vscode.ExtensionContext) {
 			// Load templates
 			const templates = await gitignoreRepository.getTemplates();
 
-			// Let the user pick a gitignore file
+			// Let the user pick gitignore file(s)
 			const items = templates.map(t => <GitignoreQuickPickItem>{
 				label: t.name,
 				description: t.path,
 				url: t.download_url,
 				template: t
 			});
-			// TODO: use thenable for items
-			const selectedItem = await vscode.window.showQuickPick(items);
+			const selectedItems = await vscode.window.showQuickPick(items, { canPickMany: true });
 
-			// Check if the user picked up a gitignore file fetched from Github
-			if (!selectedItem) {
+			// Check if the user picked any gitignore files
+			if (!selectedItems || selectedItems.length === 0) {
 				throw new CancellationError();
 			}
 
 			// Resolve the path to the folder where we should write the gitignore file
-			const { template, path } = await resolveWorkspaceFolder(selectedItem.template);
+			const { templates: selectedTemplates, path } = await resolveWorkspaceFolder(selectedItems.map(i => i.template));
 
 			// Calculate operation
 			console.log(`vscode-gitignore: add/append gitignore for directory: ${path}`);
-			const operation = await checkExistenceAndPromptForOperation(path, template);
+			const operation = await checkExistenceAndPromptForOperation(path, selectedTemplates);
 
 			// Store the file on file system
-			await downloadGitignoreFile(gitignoreRepository, operation);
+			await writeGitignoreFile(gitignoreRepository, operation);
 
 			// Show success message
 			await showSuccessMessage(operation);

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -11,6 +11,7 @@ export interface GitignoreTemplate {
 export interface GitignoreProvider {
 	getTemplates(): Promise<GitignoreTemplate[]>;
 	downloadToStream(templatePath: string, writeStream: WriteStream): Promise<void>;
+	downloadAsString(templatePath: string): Promise<string>;
 }
 
 export enum GitignoreOperationType {
@@ -27,5 +28,5 @@ export interface GitignoreOperation {
 	/**
 	 * gitignore template file to use
 	 */
-	template: GitignoreTemplate;
+	templates: GitignoreTemplate[];
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,6 +1,3 @@
-import { WriteStream } from "fs";
-
-
 export interface GitignoreTemplate {
 	name: string;
 	path: string;
@@ -10,7 +7,6 @@ export interface GitignoreTemplate {
 
 export interface GitignoreProvider {
 	getTemplates(): Promise<GitignoreTemplate[]>;
-	downloadToStream(templatePath: string, writeStream: WriteStream): Promise<void>;
 	downloadAsString(templatePath: string): Promise<string>;
 }
 
@@ -26,7 +22,7 @@ export interface GitignoreOperation {
 	 */
 	path: string;
 	/**
-	 * gitignore template file to use
+	 * gitignore template files to use
 	 */
 	templates: GitignoreTemplate[];
 }

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -1,9 +1,13 @@
-interface TemplateSection {
+export interface TemplateSection {
 	name: string;
 	content: string;
 }
 
 export function mergeTemplates(sections: TemplateSection[], deduplicate: boolean): string {
+	if (sections.length === 0) {
+		return '';
+	}
+
 	if (sections.length === 1) {
 		return sections[0].content;
 	}
@@ -24,7 +28,8 @@ export function deduplicateLines(content: string): string {
 	for (const line of lines) {
 		const trimmed = line.trimEnd();
 
-		if (trimmed === '' || trimmed.startsWith('#') || /^### .+ ###$/.test(trimmed)) {
+		// Preserve blank lines and section headers from deduplication
+		if (trimmed === '' || /^### .+\.gitignore ###$/.test(trimmed)) {
 			result.push(line);
 			continue;
 		}

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -1,0 +1,39 @@
+interface TemplateSection {
+	name: string;
+	content: string;
+}
+
+export function mergeTemplates(sections: TemplateSection[], deduplicate: boolean): string {
+	if (sections.length === 1) {
+		return sections[0].content;
+	}
+
+	const parts = sections.map(section => {
+		return `### ${section.name}.gitignore ###\n${section.content}`;
+	});
+
+	const merged = parts.join('\n\n');
+	return deduplicate ? deduplicateLines(merged) : merged;
+}
+
+export function deduplicateLines(content: string): string {
+	const lines = content.split('\n');
+	const seen = new Set<string>();
+	const result: string[] = [];
+
+	for (const line of lines) {
+		const trimmed = line.trimEnd();
+
+		if (trimmed === '' || trimmed.startsWith('#') || /^### .+ ###$/.test(trimmed)) {
+			result.push(line);
+			continue;
+		}
+
+		if (!seen.has(trimmed)) {
+			seen.add(trimmed);
+			result.push(line);
+		}
+	}
+
+	return result.join('\n');
+}

--- a/src/providers/github-gitignore-api.ts
+++ b/src/providers/github-gitignore-api.ts
@@ -1,6 +1,5 @@
 import * as https from 'https';
 import * as url from 'url';
-import { WriteStream } from 'fs';
 
 
 import { Cache, CacheItem } from '../cache';
@@ -50,22 +49,6 @@ export class GithubGitignoreApiProvider implements GitignoreProvider {
 		this.cache.add(new CacheItem('gitignore', templates));
 
 		return templates;
-	}
-
-	public async downloadToStream(templatePath: string, writeStream: WriteStream): Promise<void> {
-		/*
-		curl \
-			-H "Accept: application/vnd.github.v3.raw" \
-			https://api.github.com/gitignore/templates/Clojure
-		*/
-		const fullUrl = new url.URL(templatePath, 'https://api.github.com/gitignore/templates/');
-		const options: https.RequestOptions = {
-			agent: getAgent(),
-			method: 'GET',
-			headers: {...await this.client.getHeaders(), 'Accept': 'application/vnd.github.v3.raw'}
-		};
-
-		await this.client.requestWriteStream(fullUrl, options, writeStream);
 	}
 
 	public async downloadAsString(templatePath: string): Promise<string> {

--- a/src/providers/github-gitignore-api.ts
+++ b/src/providers/github-gitignore-api.ts
@@ -67,4 +67,14 @@ export class GithubGitignoreApiProvider implements GitignoreProvider {
 
 		await this.client.requestWriteStream(fullUrl, options, writeStream);
 	}
+
+	public async downloadAsString(templatePath: string): Promise<string> {
+		const fullUrl = new url.URL(templatePath, 'https://api.github.com/gitignore/templates/');
+		const options: https.RequestOptions = {
+			agent: getAgent(),
+			method: 'GET',
+			headers: {...await this.client.getHeaders(), 'Accept': 'application/vnd.github.v3.raw'}
+		};
+		return this.client.requestString(fullUrl, options);
+	}
 }

--- a/src/providers/github-gitignore-repository.ts
+++ b/src/providers/github-gitignore-repository.ts
@@ -105,4 +105,14 @@ export class GithubGitignoreRepositoryProvider implements GitignoreProvider {
 
 		await this.client.requestWriteStream(fullUrl, options, writeStream);
 	}
+
+	public async downloadAsString(templatePath: string): Promise<string> {
+		const fullUrl = new url.URL(templatePath, 'https://api.github.com/repos/github/gitignore/contents/');
+		const options: https.RequestOptions = {
+			agent: getAgent(),
+			method: 'GET',
+			headers: {...await this.client.getHeaders(), 'Accept': 'application/vnd.github.v3.raw'}
+		};
+		return this.client.requestString(fullUrl, options);
+	}
 }

--- a/src/providers/github-gitignore-repository.ts
+++ b/src/providers/github-gitignore-repository.ts
@@ -1,6 +1,5 @@
 import * as https from 'https';
 import * as url from 'url';
-import { WriteStream } from 'fs';
 
 import { getAgent } from '../http-client';
 import { Cache, CacheItem } from '../cache';
@@ -84,26 +83,6 @@ export class GithubGitignoreRepositoryProvider implements GitignoreProvider {
 		this.cache.add(new CacheItem('gitignore/' + path, templates));
 
 		return templates;
-	}
-
-	/**
-	 * Downloads a .gitignore from the repository to the path passed
-	 */
-	public async downloadToStream(templatePath: string, writeStream: WriteStream): Promise<void> {
-		/*
-		curl \
-			-H "Accept: application/vnd.github.v3.raw" \
-			https://api.github.com/repos/github/gitignore/contents/<path>
-		*/
-		const fullUrl = new url.URL(templatePath, 'https://api.github.com/repos/github/gitignore/contents/');
-		const options: https.RequestOptions = {
-			agent: getAgent(),
-			method: 'GET',
-			headers: {...await this.client.getHeaders(), 'Accept': 'application/vnd.github.v3.raw'}
-		};
-
-
-		await this.client.requestWriteStream(fullUrl, options, writeStream);
 	}
 
 	public async downloadAsString(templatePath: string): Promise<string> {

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -1,7 +1,7 @@
 // import * as assert from 'assert';
 
 // import * as vscode from 'vscode';
-import { downloadGitignoreFile } from '../extension';
+import { writeGitignoreFile } from '../extension';
 import { GitignoreOperation, GitignoreOperationType, GitignoreProvider, GitignoreTemplate } from '../interfaces';
 import * as fs from 'fs';
 import { createTmpTestDir } from './utils';
@@ -27,6 +27,10 @@ class GitignoreProviderMock implements GitignoreProvider {
 
 			writeStream.end();
 		});
+	}
+
+	downloadAsString(templatePath: string): Promise<string> {
+		return Promise.resolve(templatePath + "\n");
 	}
 
 }
@@ -59,12 +63,12 @@ suite('Extension Test Suite', () => {
 		const templates = await gitignoreProvider.getTemplates();
 
 		const operation = <GitignoreOperation>{
-			template: templates[0],
+			templates: [templates[0]],
 			path: path,
 			type: GitignoreOperationType.Overwrite
 		};
 
-		await downloadGitignoreFile(gitignoreProvider, operation);
+		await writeGitignoreFile(gitignoreProvider, operation);
 
 		const content = fs.readFileSync(path, {encoding: 'utf8'});
 		console.log(content);
@@ -87,12 +91,12 @@ suite('Extension Test Suite', () => {
 		const templates = await gitignoreProvider.getTemplates();
 
 		const operation = <GitignoreOperation>{
-			template: templates[0],
+			templates: [templates[0]],
 			path: path,
 			type: GitignoreOperationType.Overwrite
 		};
 
-		await downloadGitignoreFile(gitignoreProvider, operation);
+		await writeGitignoreFile(gitignoreProvider, operation);
 
 		assertLines(path, 'example', '');
 
@@ -111,16 +115,81 @@ suite('Extension Test Suite', () => {
 		const templates = await gitignoreProvider.getTemplates();
 
 		const operation = <GitignoreOperation>{
-			template: templates[0],
+			templates: [templates[0]],
 			path: path,
 			type: GitignoreOperationType.Append
 		};
 
-		await downloadGitignoreFile(gitignoreProvider, operation);
+		await writeGitignoreFile(gitignoreProvider, operation);
 
 		assertLines(path, 'existing line', '', 'example','');
 
 		// Cleanup
+		if(fs.existsSync(path)) {
+			fs.unlinkSync(path);
+		}
+	});
+
+	test('can write multi-template gitignore file', async () => {
+		const testBaseDir = await createTmpTestDir('download');
+		const path = `${testBaseDir}/.gitignore`;
+
+		const gitignoreProvider = new GitignoreProviderMock();
+
+		const templateA = <GitignoreTemplate>{ name: 'Python', path: 'Python', download_url: '', type: 'file' };
+		const templateB = <GitignoreTemplate>{ name: 'Node', path: 'Node', download_url: '', type: 'file' };
+
+		const operation = <GitignoreOperation>{
+			templates: [templateA, templateB],
+			path: path,
+			type: GitignoreOperationType.Overwrite
+		};
+
+		await writeGitignoreFile(gitignoreProvider, operation);
+
+		const content = fs.readFileSync(path, {encoding: 'utf8'});
+		assert(content.includes('### Python.gitignore ###'));
+		assert(content.includes('### Node.gitignore ###'));
+		assert(content.includes('Python'));
+		assert(content.includes('Node'));
+
+		if(fs.existsSync(path)) {
+			fs.unlinkSync(path);
+		}
+	});
+
+	test('can write multi-template gitignore file with deduplication', async () => {
+		const testBaseDir = await createTmpTestDir('download');
+		const path = `${testBaseDir}/.gitignore`;
+
+		const dedupProvider: GitignoreProvider = {
+			getTemplates: () => Promise.resolve([]),
+			downloadToStream: () => Promise.resolve(),
+			downloadAsString: (templatePath: string) => {
+				if (templatePath === 'A') {
+					return Promise.resolve('node_modules/\n*.log\n');
+				}
+				return Promise.resolve('*.log\ndist/\n');
+			}
+		};
+
+		const templateA = <GitignoreTemplate>{ name: 'A', path: 'A', download_url: '', type: 'file' };
+		const templateB = <GitignoreTemplate>{ name: 'B', path: 'B', download_url: '', type: 'file' };
+
+		const operation = <GitignoreOperation>{
+			templates: [templateA, templateB],
+			path: path,
+			type: GitignoreOperationType.Overwrite
+		};
+
+		await writeGitignoreFile(dedupProvider, operation);
+
+		const content = fs.readFileSync(path, {encoding: 'utf8'});
+		const logOccurrences = content.split('*.log').length - 1;
+		assert(logOccurrences === 1, `Expected *.log to appear once but found ${logOccurrences} times`);
+		assert(content.includes('node_modules/'));
+		assert(content.includes('dist/'));
+
 		if(fs.existsSync(path)) {
 			fs.unlinkSync(path);
 		}

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -16,18 +16,6 @@ class GitignoreProviderMock implements GitignoreProvider {
 			type: 'foo'
 		}]);
 	}
-	downloadToStream(templatePath: string, writeStream: fs.WriteStream): Promise<void> {
-		return new Promise((resolve) => {
-			writeStream.write(templatePath + "\n");
-
-			writeStream.on('finish', () => {
-				writeStream.close();
-				resolve();
-			});
-
-			writeStream.end();
-		});
-	}
 
 	downloadAsString(templatePath: string): Promise<string> {
 		return Promise.resolve(templatePath + "\n");
@@ -158,13 +146,40 @@ suite('Extension Test Suite', () => {
 		}
 	});
 
+	test('can append multi-template gitignore file', async () => {
+		const testBaseDir = await createTmpTestDir('download');
+		const path = `${testBaseDir}/.gitignore`;
+		fs.writeFileSync(path, "existing line\n");
+
+		const gitignoreProvider = new GitignoreProviderMock();
+
+		const templateA = <GitignoreTemplate>{ name: 'Python', path: 'Python', download_url: '', type: 'file' };
+		const templateB = <GitignoreTemplate>{ name: 'Node', path: 'Node', download_url: '', type: 'file' };
+
+		const operation = <GitignoreOperation>{
+			templates: [templateA, templateB],
+			path: path,
+			type: GitignoreOperationType.Append
+		};
+
+		await writeGitignoreFile(gitignoreProvider, operation);
+
+		const content = fs.readFileSync(path, {encoding: 'utf8'});
+		assert(content.startsWith('existing line\n'));
+		assert(content.includes('### Python.gitignore ###'));
+		assert(content.includes('### Node.gitignore ###'));
+
+		if(fs.existsSync(path)) {
+			fs.unlinkSync(path);
+		}
+	});
+
 	test('can write multi-template gitignore file with deduplication', async () => {
 		const testBaseDir = await createTmpTestDir('download');
 		const path = `${testBaseDir}/.gitignore`;
 
 		const dedupProvider: GitignoreProvider = {
 			getTemplates: () => Promise.resolve([]),
-			downloadToStream: () => Promise.resolve(),
 			downloadAsString: (templatePath: string) => {
 				if (templatePath === 'A') {
 					return Promise.resolve('node_modules/\n*.log\n');
@@ -195,4 +210,111 @@ suite('Extension Test Suite', () => {
 		}
 	});
 
+});
+
+suite('Multi-Template Integration Tests', () => {
+
+	test('generates correct .gitignore from two realistic templates with dedup', async () => {
+		const testBaseDir = await createTmpTestDir('integration');
+		const path = `${testBaseDir}/.gitignore`;
+
+		const pythonContent = [
+			'# Byte-compiled / optimized files',
+			'__pycache__/',
+			'*.py[cod]',
+			'',
+			'# Distribution',
+			'dist/',
+			'build/',
+		].join('\n');
+
+		const nodeContent = [
+			'# Dependencies',
+			'node_modules/',
+			'',
+			'# Build output',
+			'dist/',
+			'build/',
+		].join('\n');
+
+		const provider: GitignoreProvider = {
+			getTemplates: () => Promise.resolve([]),
+			downloadAsString: (templatePath: string) => {
+				if (templatePath === 'Python.gitignore') {
+					return Promise.resolve(pythonContent);
+				}
+				return Promise.resolve(nodeContent);
+			}
+		};
+
+		const operation = <GitignoreOperation>{
+			templates: [
+				<GitignoreTemplate>{ name: 'Python', path: 'Python.gitignore', download_url: '', type: 'file' },
+				<GitignoreTemplate>{ name: 'Node', path: 'Node.gitignore', download_url: '', type: 'file' },
+			],
+			path: path,
+			type: GitignoreOperationType.Overwrite
+		};
+
+		await writeGitignoreFile(provider, operation);
+
+		const result = fs.readFileSync(path, { encoding: 'utf8' });
+
+		const expected = [
+			'### Python.gitignore ###',
+			'# Byte-compiled / optimized files',
+			'__pycache__/',
+			'*.py[cod]',
+			'',
+			'# Distribution',
+			'dist/',
+			'build/',
+			'',
+			'### Node.gitignore ###',
+			'# Dependencies',
+			'node_modules/',
+			'',
+			'# Build output',
+		].join('\n');
+
+		assert.strictEqual(result, expected, `Expected:\n${expected}\n\nGot:\n${result}`);
+
+		assert.strictEqual(result.split('dist/').length - 1, 1, 'dist/ should appear once');
+		assert.strictEqual(result.split('build/').length - 1, 1, 'build/ should appear once');
+
+		if (fs.existsSync(path)) {
+			fs.unlinkSync(path);
+		}
+	});
+
+	test('generates correct .gitignore from single template (no headers)', async () => {
+		const testBaseDir = await createTmpTestDir('integration');
+		const path = `${testBaseDir}/.gitignore`;
+
+		const goContent = '# Binaries\n*.exe\n*.dll\n\n# Dependency directories\nvendor/\n';
+
+		const provider: GitignoreProvider = {
+			getTemplates: () => Promise.resolve([]),
+			downloadAsString: () => Promise.resolve(goContent)
+		};
+
+		const operation = <GitignoreOperation>{
+			templates: [
+				<GitignoreTemplate>{ name: 'Go', path: 'Go.gitignore', download_url: '', type: 'file' },
+			],
+			path: path,
+			type: GitignoreOperationType.Overwrite
+		};
+
+		await writeGitignoreFile(provider, operation);
+
+		const result = fs.readFileSync(path, { encoding: 'utf8' });
+
+		assert.strictEqual(result, goContent, 'Single template should produce raw content without section headers');
+		assert(!result.includes('### Go.gitignore ###'), 'No section header for single template');
+
+		if (fs.existsSync(path)) {
+			fs.unlinkSync(path);
+		}
+	});
 });

--- a/src/test/merge.test.ts
+++ b/src/test/merge.test.ts
@@ -31,16 +31,17 @@ suite('Merge Module', () => {
 		assert(result.includes('dist/'));
 	});
 
-	test('deduplication preserves comments and blank lines', () => {
-		const content = '# comment\n*.log\n\n# another comment\n*.log\n';
+	test('deduplication deduplicates comments and preserves blank lines', () => {
+		const content = '# comment\n*.log\n\n# comment\n*.log\n# another comment\n';
 		const result = deduplicateLines(content);
 
 		const comments = result.split('# comment').length - 1;
-		assert.strictEqual(comments, 1);
+		assert.strictEqual(comments, 1, 'duplicate comments should be removed');
 		const anotherComments = result.split('# another comment').length - 1;
 		assert.strictEqual(anotherComments, 1);
 		const logCount = result.split('*.log').length - 1;
 		assert.strictEqual(logCount, 1);
+		assert(result.includes('\n\n'), 'blank lines should be preserved');
 	});
 
 	test('deduplication preserves section headers', () => {
@@ -66,5 +67,20 @@ suite('Merge Module', () => {
 	test('empty content handled correctly', () => {
 		const result = mergeTemplates([{ name: 'Empty', content: '' }], false);
 		assert.strictEqual(result, '');
+	});
+
+	test('empty sections array returns empty string', () => {
+		const result = mergeTemplates([], false);
+		assert.strictEqual(result, '');
+	});
+
+	test('deduplication removes duplicate comments', () => {
+		const result = mergeTemplates([
+			{ name: 'A', content: '# Compiled source\n*.o' },
+			{ name: 'B', content: '# Compiled source\n*.class' }
+		], true);
+
+		const commentCount = result.split('# Compiled source').length - 1;
+		assert.strictEqual(commentCount, 1, `Expected 1 occurrence of comment but found ${commentCount}`);
 	});
 });

--- a/src/test/merge.test.ts
+++ b/src/test/merge.test.ts
@@ -1,0 +1,70 @@
+import assert from 'assert';
+import { mergeTemplates, deduplicateLines } from '../merge';
+
+suite('Merge Module', () => {
+	test('single section returns content without header', () => {
+		const result = mergeTemplates([{ name: 'Python', content: '*.pyc\n__pycache__/' }], false);
+		assert.strictEqual(result, '*.pyc\n__pycache__/');
+	});
+
+	test('multiple sections include headers', () => {
+		const result = mergeTemplates([
+			{ name: 'Python', content: '*.pyc' },
+			{ name: 'Node', content: 'node_modules/' }
+		], false);
+
+		assert(result.includes('### Python.gitignore ###'));
+		assert(result.includes('### Node.gitignore ###'));
+		assert(result.includes('*.pyc'));
+		assert(result.includes('node_modules/'));
+	});
+
+	test('deduplication removes duplicate patterns', () => {
+		const result = mergeTemplates([
+			{ name: 'A', content: '*.log\nnode_modules/' },
+			{ name: 'B', content: '*.log\ndist/' }
+		], true);
+
+		const logCount = result.split('*.log').length - 1;
+		assert.strictEqual(logCount, 1, `Expected 1 occurrence of *.log but found ${logCount}`);
+		assert(result.includes('node_modules/'));
+		assert(result.includes('dist/'));
+	});
+
+	test('deduplication preserves comments and blank lines', () => {
+		const content = '# comment\n*.log\n\n# another comment\n*.log\n';
+		const result = deduplicateLines(content);
+
+		const comments = result.split('# comment').length - 1;
+		assert.strictEqual(comments, 1);
+		const anotherComments = result.split('# another comment').length - 1;
+		assert.strictEqual(anotherComments, 1);
+		const logCount = result.split('*.log').length - 1;
+		assert.strictEqual(logCount, 1);
+	});
+
+	test('deduplication preserves section headers', () => {
+		const content = '### Python.gitignore ###\n*.pyc\n\n### Node.gitignore ###\n*.pyc';
+		const result = deduplicateLines(content);
+
+		assert(result.includes('### Python.gitignore ###'));
+		assert(result.includes('### Node.gitignore ###'));
+		const pycCount = result.split('*.pyc').length - 1;
+		assert.strictEqual(pycCount, 1);
+	});
+
+	test('no deduplication keeps all lines', () => {
+		const result = mergeTemplates([
+			{ name: 'A', content: '*.log' },
+			{ name: 'B', content: '*.log' }
+		], false);
+
+		const logCount = result.split('*.log').length - 1;
+		assert.strictEqual(logCount, 2);
+	});
+
+	test('empty content handled correctly', () => {
+		const result = mergeTemplates([{ name: 'Empty', content: '' }], false);
+		assert.strictEqual(result, '');
+	});
+});

--- a/src/test/providers/github-gitignore.test.ts
+++ b/src/test/providers/github-gitignore.test.ts
@@ -1,64 +1,16 @@
 import assert from 'assert';
-import * as fs from 'fs';
-import { Writable } from 'stream';
 
 import { Cache } from '../../cache';
-import { GitignoreProvider, GitignoreOperation, GitignoreTemplate, GitignoreOperationType } from '../../interfaces';
+import { GitignoreProvider, GitignoreTemplate } from '../../interfaces';
 import { GithubGitignoreApiProvider } from '../../providers/github-gitignore-api';
 import { GithubGitignoreRepositoryProvider } from '../../providers/github-gitignore-repository';
 import { GithubContext, GithubSession } from '../../github/session';
-import { createTmpTestDir } from '../utils';
-
-
-function fileExits(path: string): Promise<boolean> {
-	return new Promise((resolve) => {
-		fs.stat(path, (err) => {
-			if(err) {
-				return resolve(false);
-			}
-			return resolve(true);
-		});
-	});
-}
-
-
 
 
 const providers: GitignoreProvider[] = [
 	new GithubGitignoreRepositoryProvider(new Cache(0), new GithubSession(new GithubContext())),
 	new GithubGitignoreApiProvider(new Cache(0), new GithubSession(new GithubContext())),
 ];
-
-/**
- * An implementation of a stream.Writable that writes to a string member.
- * This class is designed for unit test purposes only.
- */
-class MemoryWritable extends Writable {
-	bytesWritten = 0;
-	path: string | Buffer = '<memory>';
-	pending = false;
-
-	private data = '';
-
-	constructor() {
-		super();
-	}
-
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	_write(chunk: any, _encoding: BufferEncoding, callback: (error?: Error | null) => void): void {
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-		this.data += chunk.toString();
-		callback();
-	}
-
-	close(): void {
-		// Do nothing
-	}
-
-	public get content() : string {
-		return this.data;
-	}
-}
 
 providers.forEach(provider => {
 
@@ -72,156 +24,6 @@ providers.forEach(provider => {
 
 			assert(templates.length > 0);
 			assert(templates.find(t => t.name === 'Clojure') !== undefined);
-		});
-
-		test('can download a template to a file', async () => {
-			// TODO: Check content of file
-			const testBaseDir = await createTmpTestDir(provider.constructor.name);
-			const path = `${testBaseDir}/.gitignore`;
-
-			// Cleanup
-			if(fs.existsSync(path)) {
-				fs.unlinkSync(path);
-			}
-
-			const operation = <GitignoreOperation>{
-				templates: [templates.find(t => t.name === 'C')!],
-				path: path,
-				type: GitignoreOperationType.Overwrite
-			};
-
-			const fileStream = fs.createWriteStream(operation.path, { flags: "w" });
-			await provider.downloadToStream(operation.templates[0].path, fileStream);
-
-			// Assert
-			const fileExists = await fileExits(operation.path);
-			assert(fileExists);
-
-			const content = fs.readFileSync(operation.path, {encoding: 'utf8'});
-			const lines = content.split(/\r?\n/);
-
-			assert(lines[0] === '# Prerequisites');
-			assert(lines[1] === '*.d');
-			assert(lines[2] === '');
-
-			// Cleanup
-			if(fs.existsSync(path)) {
-				fs.unlinkSync(path);
-			}
-		});
-
-		test('can download a root template (regular) to a writable stream', async () => {
-			const memoryStream = new MemoryWritable();
-
-			const path = provider.constructor.name + '.gitignore';
-
-			const operation = <GitignoreOperation>{
-				templates: [templates.find(t => t.name === 'Python')!],
-				path: path,
-				type: GitignoreOperationType.Overwrite
-			};
-
-			// Act
-			await provider.downloadToStream(operation.templates[0].path, memoryStream);
-
-			// Assert
-			const content = memoryStream.content;
-			const lines = content.split(/\r?\n/);
-
-			assert(lines[0] === '# Byte-compiled / optimized / DLL files');
-			assert(lines[1] === '__pycache__/');
-			assert(lines[2] === '*.py[cod]');
-		});
-
-		// Test for bug #21
-		// https://github.com/CodeZombieCH/vscode-gitignore/issues/21
-		test('can download a root template (symlink) to a writable stream', async () => {
-			const memoryStream = new MemoryWritable();
-
-			const path = provider.constructor.name + '.gitignore';
-
-			const operation = <GitignoreOperation>{
-				templates: [templates.find(t => t.name === 'Clojure')!],
-				path: path,
-				type: GitignoreOperationType.Overwrite
-			};
-
-			// Act
-			await provider.downloadToStream(operation.templates[0].path, memoryStream);
-
-			// Assert
-			const content = memoryStream.content;
-			const lines = content.split(/\r?\n/);
-
-			// Ensure the content is not the name of the linked file
-			assert(lines[0] !== 'Leiningen.gitignore');
-
-			assert(lines[0] === 'pom.xml');
-			assert(lines[1] === 'pom.xml.asc');
-			assert(lines[2] === '*.jar');
-		});
-
-		test('can download global a template to a writable stream', async () => {
-			if(provider.constructor.name === GithubGitignoreApiProvider.name) {
-				// Skip test for GithubGitignoreApiProvider
-				// Not supported by the API
-				return;
-			}
-
-			const memoryStream = new MemoryWritable();
-
-			const path = provider.constructor.name + '.gitignore';
-
-			const operation = <GitignoreOperation>{
-				templates: [templates.find(t => t.name === 'VisualStudioCode')!],
-				path: path,
-				type: GitignoreOperationType.Overwrite
-			};
-
-			// Act
-			await provider.downloadToStream(operation.templates[0].path, memoryStream);
-
-			// Assert
-			const content = memoryStream.content;
-			const lines = content.split(/\r?\n/);
-
-			assert(lines[0] === '.vscode/*');
-			assert(lines[1] === '!.vscode/settings.json');
-			assert(lines[2] === '!.vscode/tasks.json');
-		});
-
-		// Test for bug #21
-		// https://github.com/CodeZombieCH/vscode-gitignore/issues/21
-		test('can download a global template (symlink) to a writable stream', async () => {
-			if(provider.constructor.name === GithubGitignoreApiProvider.name) {
-				// Skip test for GithubGitignoreApiProvider
-				// Not supported by the API
-				return;
-			}
-
-			const memoryStream = new MemoryWritable();
-
-			const path = provider.constructor.name + '.gitignore';
-
-			const operation = <GitignoreOperation>{
-				templates: [templates.find(t => t.name === 'Octave')!],
-				path: path,
-				type: GitignoreOperationType.Overwrite
-			};
-
-			// Act
-			await provider.downloadToStream(operation.templates[0].path, memoryStream);
-
-			// Assert
-			const content = memoryStream.content;
-			const lines = content.split(/\r?\n/);
-
-			// Ensure the content is not the name of the linked file
-			assert(lines[0] !== 'MATLAB.gitignore');
-
-			assert(lines[0] === '# Windows default autosave extension');
-			assert(lines[1] === '*.asv');
-			assert(lines[2] === '');
 		});
 
 		test('can download a template as string', async () => {

--- a/src/test/providers/github-gitignore.test.ts
+++ b/src/test/providers/github-gitignore.test.ts
@@ -85,13 +85,13 @@ providers.forEach(provider => {
 			}
 
 			const operation = <GitignoreOperation>{
-				template: templates.find(t => t.name === 'C'),
+				templates: [templates.find(t => t.name === 'C')!],
 				path: path,
 				type: GitignoreOperationType.Overwrite
 			};
 
 			const fileStream = fs.createWriteStream(operation.path, { flags: "w" });
-			await provider.downloadToStream(operation.template.path, fileStream);
+			await provider.downloadToStream(operation.templates[0].path, fileStream);
 
 			// Assert
 			const fileExists = await fileExits(operation.path);
@@ -116,13 +116,13 @@ providers.forEach(provider => {
 			const path = provider.constructor.name + '.gitignore';
 
 			const operation = <GitignoreOperation>{
-				template: templates.find(t => t.name === 'Python'),
+				templates: [templates.find(t => t.name === 'Python')!],
 				path: path,
 				type: GitignoreOperationType.Overwrite
 			};
 
 			// Act
-			await provider.downloadToStream(operation.template.path, memoryStream);
+			await provider.downloadToStream(operation.templates[0].path, memoryStream);
 
 			// Assert
 			const content = memoryStream.content;
@@ -141,13 +141,13 @@ providers.forEach(provider => {
 			const path = provider.constructor.name + '.gitignore';
 
 			const operation = <GitignoreOperation>{
-				template: templates.find(t => t.name === 'Clojure'),
+				templates: [templates.find(t => t.name === 'Clojure')!],
 				path: path,
 				type: GitignoreOperationType.Overwrite
 			};
 
 			// Act
-			await provider.downloadToStream(operation.template.path, memoryStream);
+			await provider.downloadToStream(operation.templates[0].path, memoryStream);
 
 			// Assert
 			const content = memoryStream.content;
@@ -173,13 +173,13 @@ providers.forEach(provider => {
 			const path = provider.constructor.name + '.gitignore';
 
 			const operation = <GitignoreOperation>{
-				template: templates.find(t => t.name === 'VisualStudioCode'),
+				templates: [templates.find(t => t.name === 'VisualStudioCode')!],
 				path: path,
 				type: GitignoreOperationType.Overwrite
 			};
 
 			// Act
-			await provider.downloadToStream(operation.template.path, memoryStream);
+			await provider.downloadToStream(operation.templates[0].path, memoryStream);
 
 			// Assert
 			const content = memoryStream.content;
@@ -204,13 +204,13 @@ providers.forEach(provider => {
 			const path = provider.constructor.name + '.gitignore';
 
 			const operation = <GitignoreOperation>{
-				template: templates.find(t => t.name === 'Octave'),
+				templates: [templates.find(t => t.name === 'Octave')!],
 				path: path,
 				type: GitignoreOperationType.Overwrite
 			};
 
 			// Act
-			await provider.downloadToStream(operation.template.path, memoryStream);
+			await provider.downloadToStream(operation.templates[0].path, memoryStream);
 
 			// Assert
 			const content = memoryStream.content;
@@ -222,6 +222,16 @@ providers.forEach(provider => {
 			assert(lines[0] === '# Windows default autosave extension');
 			assert(lines[1] === '*.asv');
 			assert(lines[2] === '');
+		});
+
+		test('can download a template as string', async () => {
+			const template = templates.find(t => t.name === 'Python');
+			assert(template !== undefined, 'Python template not found');
+
+			const content = await provider.downloadAsString(template.path);
+			const lines = content.split(/\r?\n/);
+			assert(lines[0] === '# Byte-compiled / optimized / DLL files');
+			assert(lines[1] === '__pycache__/');
 		});
 	});
 


### PR DESCRIPTION
## Summary
- QuickPick now supports selecting multiple `.gitignore` templates at once via `canPickMany`
- Selected templates are merged with `### <name>.gitignore ###` section headers
- Duplicate pattern lines and comments are automatically deduplicated (configurable via `gitignore.deduplicateLines` setting)
- Removed unused `downloadToStream` from the `GitignoreProvider` interface in favor of `downloadAsString`

## Test plan
- [x] Compile, lint, and type-check pass
- [x] All 25 tests pass (unit + integration)
- [x] Manually test single-template selection still works as before
- [x] Manually test multi-template selection produces merged `.gitignore` with section headers
- [x] Verify append mode preserves existing file content
- [x] Verify dedup setting toggle works via `gitignore.deduplicateLines`